### PR TITLE
73 - Fix coordinates in plot_maze

### DIFF
--- a/maze_transformer/evaluation/plot_maze.py
+++ b/maze_transformer/evaluation/plot_maze.py
@@ -44,15 +44,14 @@ def plot_multi_paths(
     show: bool = True,
 ) -> None:
     # show the maze
-    img = maze.as_img()
     plt.imshow(
-        np.rot90(img, 1),
+        maze.as_img(),
         cmap="gray",
         extent=[
             -0.75,
             maze.grid_shape[0] - 1 + 0.75,
-            -0.75,
             maze.grid_shape[1] - 1 + 0.75,
+            -0.75,
         ],
     )
 
@@ -63,10 +62,12 @@ def plot_multi_paths(
 
         # p_transformed: NDArray = maze.points_transform_to_img(pf.path)
         p_transformed: NDArray = np.array(pf.path)
-
         if pf.quiver_kwargs is not None:
-            x: NDArray = p_transformed[:, 0]
-            y: NDArray = p_transformed[:, 1]
+            # Pyplot uses Cartesian coordinates (x horixontal and y vertical)
+            # But our mazes and paths use array notation (row, col)
+            # So we swap the dimensions here
+            y: NDArray = p_transformed[:, 0]
+            x: NDArray = p_transformed[:, 1]
             plt.quiver(
                 x[:-1],
                 y[:-1],
@@ -81,8 +82,8 @@ def plot_multi_paths(
         else:
             plt.plot(*zip(*p_transformed), pf.fmt, color=pf.color, label=pf.label)
         # mark endpoints
-        plt.plot([p_transformed[0][0]], [p_transformed[0][1]], "o", color=pf.color)
-        plt.plot([p_transformed[-1][0]], [p_transformed[-1][1]], "x", color=pf.color)
+        plt.plot([p_transformed[0][1]], [p_transformed[0][0]], "o", color=pf.color)
+        plt.plot([p_transformed[-1][1]], [p_transformed[-1][0]], "x", color=pf.color)
 
     if show:
         plt.show()

--- a/maze_transformer/evaluation/plot_maze.py
+++ b/maze_transformer/evaluation/plot_maze.py
@@ -13,13 +13,13 @@ def plot_path(maze: LatticeMaze, path: NDArray, show: bool = True) -> None:
     img = maze.as_img()
     path_transformed = maze.points_transform_to_img(path)
 
-    # plot path
-    plt.plot(*zip(*path_transformed), "-", color="red")
+    # dimension swap -  we are translating from array notation to cartesian coordinates
+    plt.plot(path_transformed[:, 1], path_transformed[:, 0], "-", color="red")
     # mark endpoints
-    plt.plot([path_transformed[0][0]], [path_transformed[0][1]], "o", color="red")
-    plt.plot([path_transformed[-1][0]], [path_transformed[-1][1]], "x", color="red")
+    plt.plot([path_transformed[0][1]], [path_transformed[0][0]], "o", color="red")
+    plt.plot([path_transformed[-1][1]], [path_transformed[-1][0]], "x", color="red")
     # show actual maze
-    plt.imshow(img.T, cmap="gray", vmin=-1, vmax=1)
+    plt.imshow(img, cmap="gray", vmin=-1, vmax=1)
 
     if show:
         plt.show()
@@ -66,8 +66,8 @@ def plot_multi_paths(
             # Pyplot uses Cartesian coordinates (x horixontal and y vertical)
             # But our mazes and paths use array notation (row, col)
             # So we swap the dimensions here
-            y: NDArray = p_transformed[:, 0]
             x: NDArray = p_transformed[:, 1]
+            y: NDArray = p_transformed[:, 0]
             plt.quiver(
                 x[:-1],
                 y[:-1],


### PR DESCRIPTION
I believe this resolves #73 

The issue was that in our generation and tokenization code we are using array notation for all coordinates - (row, col). But matplotlib uses Cartesian coordinates - (x, y). These are opposites, which caused a lot of confusion in `plot_maze.py` where we are plotting mazes and paths.

There are 2 fixes here:
- Swap the dimensions of the path coordinates when we plot them in matplotlib
- Fix usage of `extent` which was causing origin to appear at the bottom instead of the top.

**Note**: I don't have any tests for this yet. Both of these functions are just rendering plots so unit tests are a bit of a pain. I'll have to extract out all the logic involved in calculating the inputs for `plt.plot`  into seperate functions and test those. Putting the PR up now so I can get a sanity check on the actual fix while I work on tests and refactoring.

Plots after fix:

![Screenshot 2023-03-13 at 3 37 52 PM](https://user-images.githubusercontent.com/7400942/224820886-8b38a5fd-4bce-4d04-8844-01baa66e5b43.png)
![Screenshot 2023-03-13 at 4 01 03 PM](https://user-images.githubusercontent.com/7400942/224820984-08f4eab9-678c-463e-a7aa-f10de64fb6f7.png)
