### PR TITLE
Break SolvedMaze out of MazeTokenizer

### DIFF
--- a/maze_transformer/generation/generators.py
+++ b/maze_transformer/generation/generators.py
@@ -3,7 +3,12 @@ from typing import Any, Callable
 
 import numpy as np
 
-from maze_transformer.generation.latticemaze import NEIGHBORS_MASK, Coord, LatticeMaze
+from maze_transformer.generation.latticemaze import (
+    NEIGHBORS_MASK,
+    Coord,
+    LatticeMaze,
+    SolvedMaze,
+)
 
 
 class LatticeMazeGenerators:
@@ -14,7 +19,7 @@ class LatticeMazeGenerators:
         grid_shape: Coord,
         start_coord: Coord | None = None,
         lattice_dim: int = 2,
-    ) -> "LatticeMaze":
+    ) -> LatticeMaze:
         """generate a lattice maze using depth first search, iterative
 
         algorithm:
@@ -93,6 +98,13 @@ class LatticeMazeGenerators:
                 start_coord=start_coord,
             ),
         )
+
+    @classmethod
+    def gen_dfs_with_solution(cls, grid_shape: Coord):
+        maze = cls.gen_dfs(grid_shape)
+        solution = np.array(maze.generate_random_path())
+
+        return SolvedMaze(maze, solution)
 
 
 GENERATORS_MAP: dict[str, Callable[[Coord, Any], "LatticeMaze"]] = {

--- a/maze_transformer/generation/latticemaze.py
+++ b/maze_transformer/generation/latticemaze.py
@@ -1,5 +1,6 @@
 import random
 from dataclasses import dataclass
+from typing import NamedTuple
 
 import numpy as np
 from muutils.misc import list_split
@@ -382,3 +383,10 @@ class LatticeMaze:
             adjlist[i, 1] = np.array(coord_str_to_tuple(c_end))
 
         return cls.from_adjlist(adjlist)
+
+
+class SolvedMaze(NamedTuple):
+    """Stores a maze and a solution"""
+
+    maze: LatticeMaze
+    solution: list[tuple[int, int]]

--- a/notebooks/plot_attention.ipynb
+++ b/notebooks/plot_attention.ipynb
@@ -1,1115 +1,1110 @@
 {
- "cells": [
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# Generic\n",
-    "import html\n",
-    "import os\n",
-    "from pathlib import Path\n",
-    "\n",
-    "# Transformers\n",
-    "from circuitsvis.attention import attention_heads\n",
-    "from circuitsvis.tokens import colored_tokens_multi\n",
-    "\n",
-    "# Numerical Computing\n",
-    "import numpy as np\n",
-    "import torch\n",
-    "\n",
-    "# Our Code\n",
-    "from maze_transformer.utils.notebook_utils import configure_notebook\n",
-    "from maze_transformer.generation.latticemaze import LatticeMaze\n",
-    "from maze_transformer.generation.generators import LatticeMazeGenerators\n",
-    "from maze_transformer.training.tokenizer import MazeTokenizer, SPECIAL_TOKENS\n",
-    "from maze_transformer.evaluation.plot_maze import plot_multi_paths, PathFormat\n",
-    "from maze_transformer.evaluation.eval_model import decode_maze_tokens_to_coords, load_model_with_configs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# Setup\n",
-    "device = configure_notebook(seed=42, dark_mode=True)\n",
-    "# We won't be training any models\n",
-    "torch.set_grad_enabled(False)\n",
-    "\n",
-    "# Get latest model\n",
-    "# this should point towards a directory containing a run. \n",
-    "# If you don't have any runs, you can create a dataset with `poetry run python scripts/create_dataset.py create ./data/maze 10 --grid_n=4`\n",
-    "# Then train a model with poetry run python scripts/train_model.py ./data/maze/g4-n10`\n",
-    "run_path = Path(\"../data/maze/g4-n10\")\n",
-    "assert run_path.exists(), f\"Run path {run_path.as_posix()} does not exist\"\n",
-    "model_path = list(sorted(run_path.glob(\"**/model.final.pt\"), key=os.path.getmtime))[\n",
-    "\t-1\n",
-    "].resolve()\n",
-    "model, cfg = load_model_with_configs(model_path)\n",
-    "maze_path = run_path / \"maze_tokens.jsonl\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# generate a maze\n",
-    "grid_n: int = cfg.dataset_cfg.grid_n\n",
-    "maze: LatticeMaze = LatticeMazeGenerators.gen_dfs((grid_n, grid_n))\n",
-    "c_start = (0, 0)\n",
-    "c_end = (grid_n - 1, grid_n - 1)\n",
-    "\n",
-    "# solve the maze explicitly\n",
-    "path_true = np.array(maze.find_shortest_path(\n",
-    "\tc_start = c_start,\n",
-    "\tc_end = c_end,\n",
-    "))\n",
-    "\n",
-    "solved_maze: MazeTokenizer = MazeTokenizer(\n",
-    "\tmaze=maze,\n",
-    "\tsolution=np.array(maze.find_shortest_path(\n",
-    "\t\tc_start=c_start,\n",
-    "\t\tc_end=c_end,\n",
-    "\t)),\n",
-    ")\n",
-    "\n",
-    "# tokenize the maze\n",
-    "maze_only_tokens: list[str] = solved_maze.as_tokens(cfg.dataset_cfg.node_token_map , solution = False) + [ SPECIAL_TOKENS[\"path_start\"] ]\n",
-    "\n",
-    "print(\"maze tokens:\", maze_only_tokens)\n",
-    "\n",
-    "array_nopad = torch.tensor(\n",
-    "\t[ cfg.dataset_cfg.tokenizer_map[t] for t in maze_only_tokens ], \n",
-    "\tdtype=torch.int32,\n",
-    "\tdevice=\"cpu\",\n",
-    ")\n",
-    "array = array_nopad\n",
-    "# print(model.to_tokens(maze_only_tokens))\n",
-    "# array: torch.Tensor = pad_sequence(array_nopad, cfg)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# have the model predict some tokens\n",
-    "context_str: list[str] = maze_only_tokens\n",
-    "\n",
-    "# escape for html\n",
-    "context_str = [ html.escape(t) for t in context_str ]\n",
-    "\n",
-    "array_tensor = torch.tensor(array).long().unsqueeze(0).to(device)\n",
-    "with torch.no_grad():\n",
-    "\tlogits, cache = model.run_with_cache(array_tensor)\n",
-    "\n",
-    "attentions = [w for k, w in cache.items() if 'hook_pattern' in k]\n",
-    "print(f\"{logits.shape = }\\n{len(attentions) = }\\n{[x.shape for x in attentions] = }\")\n",
-    "\n",
-    "# `output.attentions` is a tuple of tensors, where each element of the tuple corresponds to a layer. \n",
-    "#  The tensor has dimensions (1, n_heads, n_positions, n_positions)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "n_layers: int = len(attentions)\n",
-    "n_heads: int = attentions[0].shape[1]\n",
-    "n_tokens: int = attentions[0].shape[2]\n",
-    "attention_to_plot = torch.concatenate(attentions, dim=0).reshape(-1, n_tokens, n_tokens)\n",
-    "attention_head_names = [f\"Layer {i} Head {j}\" for i in range(n_layers) for j in range(n_heads)]\n",
-    "attention_heads(attention_to_plot,maze_only_tokens, attention_head_names)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "#! ALEX note - there used to be a np.power(head_np, 1/4) here, not sure what that's about?\n",
-    "FROM_TOKEN = -1 # Look at attention from this token position to the rest of the sequence\n",
-    "attentions_from_token = torch.concatenate([w[0, :, FROM_TOKEN, :] for w in attentions], dim=0)\n",
-    "colored_tokens_multi(context_str, attentions_from_token.T, labels=attention_head_names)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "eos_id = cfg.dataset_cfg.tokenizer_map[SPECIAL_TOKENS[\"path_end\"]]\n",
-    "predictions = model.generate(array_tensor, max_new_tokens=50, \n",
-    "                        \teos_token_id=eos_id, stop_at_eos=True)\n",
-    "#! TODO stop_eos to True once wrapped tokenizer is in the HookedTransformer\n",
-    "\n",
-    "# decode the tokens\n",
-    "predicted_tokens = [ cfg.dataset_cfg.token_arr[t] for t in predictions[0] ]\n",
-    "\n",
-    "path_predicted: list[tuple[int,int]] = decode_maze_tokens_to_coords(\n",
-    "\tpredicted_tokens[len(maze_only_tokens):],\n",
-    "\tmazedata_cfg = cfg.dataset_cfg, \n",
-    "\twhen_noncoord = \"skip\",\n",
-    ")\n",
-    "\n",
-    "# plot the maze and both solutions\n",
-    "# for label, fmt, color, path in paths\n",
-    "plot_multi_paths(\n",
-    "\tmaze = maze,\n",
-    "\tpaths = [\n",
-    "\t\tPathFormat(path_true, \"true\", \"-\", \"red\", {'width': 0.015}),\n",
-    "\t\tPathFormat(np.array(path_predicted), \"predicted\", \":\", \"blue\", {}),\n",
-    "\t],\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": []
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "mml_cw_new",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.10"
-  },
-  "orig_nbformat": 4,
-  "vscode": {
-   "interpreter": {
-    "hash": "170637793197da0d440deb6cb249c898d613b24c548839ecbbac11596710dfc2"
-   }
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 2
+    "cells": [
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": [
+                "# Generic\n",
+                "import html\n",
+                "import os\n",
+                "from pathlib import Path\n",
+                "\n",
+                "# Transformers\n",
+                "from circuitsvis.attention import attention_heads\n",
+                "from circuitsvis.tokens import colored_tokens_multi\n",
+                "\n",
+                "# Numerical Computing\n",
+                "import numpy as np\n",
+                "import torch\n",
+                "\n",
+                "# Our Code\n",
+                "from maze_transformer.utils.notebook_utils import configure_notebook\n",
+                "from maze_transformer.generation.latticemaze import LatticeMaze, SolvedMaze\n",
+                "from maze_transformer.generation.generators import LatticeMazeGenerators\n",
+                "from maze_transformer.training.tokenizer import maze_to_tokens, SPECIAL_TOKENS\n",
+                "from maze_transformer.evaluation.plot_maze import plot_multi_paths, PathFormat\n",
+                "from maze_transformer.evaluation.eval_model import decode_maze_tokens_to_coords, load_model_with_configs"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": [
+                "# Setup\n",
+                "device = configure_notebook(seed=42, dark_mode=True)\n",
+                "# We won't be training any models\n",
+                "torch.set_grad_enabled(False)\n",
+                "\n",
+                "# Get latest model\n",
+                "# this should point towards a directory containing a run. \n",
+                "# If you don't have any runs, you can create a dataset with `poetry run python scripts/create_dataset.py create ./data/maze 10 --grid_n=4`\n",
+                "# Then train a model with poetry run python scripts/train_model.py ./data/maze/g4-n10`\n",
+                "run_path = Path(\"../data/maze/g4-n10\")\n",
+                "assert run_path.exists(), f\"Run path {run_path.as_posix()} does not exist\"\n",
+                "model_path = list(sorted(run_path.glob(\"**/model.final.pt\"), key=os.path.getmtime))[\n",
+                "\t-1\n",
+                "].resolve()\n",
+                "model, cfg = load_model_with_configs(model_path)\n",
+                "maze_path = run_path / \"maze_tokens.jsonl\""
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": [
+                "# generate a maze\n",
+                "grid_n: int = cfg.dataset_cfg.grid_n\n",
+                "maze: LatticeMaze = LatticeMazeGenerators.gen_dfs((grid_n, grid_n))\n",
+                "c_start = (0, 0)\n",
+                "c_end = (grid_n - 1, grid_n - 1)\n",
+                "\n",
+                "# solve the maze explicitly\n",
+                "path_true = np.array(maze.find_shortest_path(\n",
+                "\tc_start = c_start,\n",
+                "\tc_end = c_end,\n",
+                "))\n",
+                "\n",
+                "\n",
+                "# tokenize the maze\n",
+                "tokens = maze_to_tokens(maze, path_true, cfg.dataset_cfg.node_token_map)\n",
+                "path_start_index = tokens.index(SPECIAL_TOKENS[\"path_start\"])\n",
+                "maze_only_tokens = tokens[:path_start_index + 1]\n",
+                "\n",
+                "print(\"maze tokens:\", maze_only_tokens)\n",
+                "\n",
+                "array_nopad = torch.tensor(\n",
+                "\t[ cfg.dataset_cfg.tokenizer_map[t] for t in maze_only_tokens ], \n",
+                "\tdtype=torch.int32,\n",
+                "\tdevice=\"cpu\",\n",
+                ")\n",
+                "array = array_nopad\n",
+                "# print(model.to_tokens(maze_only_tokens))\n",
+                "# array: torch.Tensor = pad_sequence(array_nopad, cfg)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": [
+                "# have the model predict some tokens\n",
+                "context_str: list[str] = maze_only_tokens\n",
+                "\n",
+                "# escape for html\n",
+                "context_str = [ html.escape(t) for t in context_str ]\n",
+                "\n",
+                "array_tensor = torch.tensor(array).long().unsqueeze(0).to(device)\n",
+                "with torch.no_grad():\n",
+                "\tlogits, cache = model.run_with_cache(array_tensor)\n",
+                "\n",
+                "attentions = [w for k, w in cache.items() if 'hook_pattern' in k]\n",
+                "print(f\"{logits.shape = }\\n{len(attentions) = }\\n{[x.shape for x in attentions] = }\")\n",
+                "\n",
+                "# `output.attentions` is a tuple of tensors, where each element of the tuple corresponds to a layer. \n",
+                "#  The tensor has dimensions (1, n_heads, n_positions, n_positions)\n"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": [
+                "n_layers: int = len(attentions)\n",
+                "n_heads: int = attentions[0].shape[1]\n",
+                "n_tokens: int = attentions[0].shape[2]\n",
+                "attention_to_plot = torch.concatenate(attentions, dim=0).reshape(-1, n_tokens, n_tokens)\n",
+                "attention_head_names = [f\"Layer {i} Head {j}\" for i in range(n_layers) for j in range(n_heads)]\n",
+                "attention_heads(attention_to_plot,maze_only_tokens, attention_head_names)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": [
+                "#! ALEX note - there used to be a np.power(head_np, 1/4) here, not sure what that's about?\n",
+                "FROM_TOKEN = -1 # Look at attention from this token position to the rest of the sequence\n",
+                "attentions_from_token = torch.concatenate([w[0, :, FROM_TOKEN, :] for w in attentions], dim=0)\n",
+                "colored_tokens_multi(context_str, attentions_from_token.T, labels=attention_head_names)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": [
+                "eos_id = cfg.dataset_cfg.tokenizer_map[SPECIAL_TOKENS[\"path_end\"]]\n",
+                "predictions = model.generate(array_tensor, max_new_tokens=50, \n",
+                "                        \teos_token_id=eos_id, stop_at_eos=True)\n",
+                "#! TODO stop_eos to True once wrapped tokenizer is in the HookedTransformer\n",
+                "\n",
+                "# decode the tokens\n",
+                "predicted_tokens = [ cfg.dataset_cfg.token_arr[t] for t in predictions[0] ]\n",
+                "\n",
+                "path_predicted: list[tuple[int,int]] = decode_maze_tokens_to_coords(\n",
+                "\tpredicted_tokens[len(maze_only_tokens):],\n",
+                "\tmazedata_cfg = cfg.dataset_cfg, \n",
+                "\twhen_noncoord = \"skip\",\n",
+                ")\n",
+                "\n",
+                "# plot the maze and both solutions\n",
+                "# for label, fmt, color, path in paths\n",
+                "plot_multi_paths(\n",
+                "\tmaze = maze,\n",
+                "\tpaths = [\n",
+                "\t\tPathFormat(path_true, \"true\", \"-\", \"red\", {'width': 0.015}),\n",
+                "\t\tPathFormat(np.array(path_predicted), \"predicted\", \":\", \"blue\", {}),\n",
+                "\t],\n",
+                ")"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {
+                "collapsed": false,
+                "pycharm": {
+                    "name": "#%%\n"
+                }
+            },
+            "outputs": [],
+            "source": []
+        }
+    ],
+    "metadata": {
+        "kernelspec": {
+            "display_name": "maze-transformer",
+            "language": "python",
+            "name": "maze-transformer"
+        },
+        "language_info": {
+            "codemirror_mode": {
+                "name": "ipython",
+                "version": 3
+            },
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+            "version": "3.10.10"
+        },
+        "orig_nbformat": 4,
+        "vscode": {
+            "interpreter": {
+                "hash": "170637793197da0d440deb6cb249c898d613b24c548839ecbbac11596710dfc2"
+            }
+        }
+    },
+    "nbformat": 4,
+    "nbformat_minor": 2
 }

--- a/tests/unit/maze_transformer/training/test_maze_dataset.py
+++ b/tests/unit/maze_transformer/training/test_maze_dataset.py
@@ -3,36 +3,36 @@ import random
 import numpy as np
 
 from maze_transformer.generation.generators import LatticeMazeGenerators
-from maze_transformer.generation.latticemaze import CoordTup, LatticeMaze
-from maze_transformer.training.mazedataset import MazeDatasetConfig, maze_to_tokens
-from maze_transformer.training.tokenizer import MazeTokenizer
+from maze_transformer.generation.latticemaze import LatticeMaze, SolvedMaze
+from maze_transformer.training.mazedataset import (
+    MazeDatasetConfig,
+    solved_maze_to_tokens,
+)
 
 
-def test_maze_to_tokens():
+def test_solved_maze_to_tokens():
     random.seed(42)
     np.random.seed(42)
     # generate a maze
     grid_n: int = 2
     maze: LatticeMaze = LatticeMazeGenerators.gen_dfs((grid_n, grid_n))
 
-    # generate a maze tokenizer
-    c_start: CoordTup = (1, 1)
-    c_end: CoordTup = (0, 0)
-    maze_tokenizer = MazeTokenizer(
-        maze=maze,
-        solution=np.array(
-            maze.find_shortest_path(
-                c_start=c_start,
-                c_end=c_end,
-            )
-        ),
+    solution = np.array(
+        maze.find_shortest_path(
+            c_start=(1, 1),
+            c_end=(0, 0),
+        )
     )
 
     # generate a dataset config
-    n_mazes: int = 10
-    dataset_cfg = MazeDatasetConfig(name="test", grid_n=grid_n, n_mazes=n_mazes)
+    node_token_map = MazeDatasetConfig(
+        name="test", grid_n=grid_n, n_mazes=10
+    ).node_token_map
 
-    tokens: list[str] = maze_to_tokens(maze_tokenizer, dataset_cfg.node_token_map)
+    solved_maze = SolvedMaze(maze, solution)
+
+    tokens: list[str] = solved_maze_to_tokens(solved_maze, node_token_map)
+
     expected: list[str] = [
         "<ADJLIST_START>",
         "(1,1)",

--- a/tests/unit/maze_transformer/training/test_tokenizer.py
+++ b/tests/unit/maze_transformer/training/test_tokenizer.py
@@ -1,19 +1,17 @@
-import numpy as np
-
 from maze_transformer.generation.generators import LatticeMazeGenerators
 from maze_transformer.training.mazedataset import MazeDatasetConfig
-from maze_transformer.training.tokenizer import SPECIAL_TOKENS, MazeTokenizer
+from maze_transformer.training.tokenizer import SPECIAL_TOKENS, maze_to_tokens
 from tests.helpers import utils
 
 
 def test_coordinate_system():
     """
-    Check that the adjlist created by .as_tokens() uses the same coordinate system as the LatticeMaze adjlist.
+    Check that the adjlist created by .maze_to_tokens() uses the same coordinate system as the LatticeMaze adjlist.
 
     To test this, generate both adjlists, sort them and convert to a common format, and check that they are equal.
     """
     maze_size = 3
-    maze = LatticeMazeGenerators.gen_dfs((maze_size, maze_size))
+    maze, solution = LatticeMazeGenerators.gen_dfs_with_solution((maze_size, maze_size))
     maze_adjlist = maze.as_adj_list()
 
     # convert to the same format as the tokenizer adjlist
@@ -26,10 +24,7 @@ def test_coordinate_system():
         grid_n=maze_size, name="test", n_mazes=1
     ).node_token_map
 
-    tokenized_maze = MazeTokenizer(
-        maze=maze,
-        solution=np.array([[0, 0]]),
-    ).as_tokens(node_token_map)
+    tokenized_maze = maze_to_tokens(maze, solution, node_token_map)
 
     tokenizer_adjlist = tokenized_maze[
         tokenized_maze.index(SPECIAL_TOKENS["adjlist_start"])


### PR DESCRIPTION
Some relatively minor refactoring.

I noticed that `MazeTokenizer` had 2 distinct roles:

1. Store a maze and a solution together
2. Tokenize a maze

I think this caused some confusion in the code in a few places.

I've broken the first role out into a separate `SolvedMaze` class, which is just a NamedTuple that stores a maze and a solution. This leaves just the tokenization function behind in `tokenizer.py`, which should pave the way to move it into @afspies new Tokenizer when that gets merged. Doing this let me simplify things in a few other places, especially the create_dataset script.

I decided to go with a new class rather than putting a `solution` attr directly on `LatticeMaze` for a few reasons:
- Conceptually mazes and solutions are distinct
- I'm not confident that it will always make sense for mazes to only store one solution, so I don't want to bake that into the main class.
- If it was on the class, then when you're working with a `LatticeMaze` object in a notebook, you would never be quite sure if it contained a solution or not. With a `SolvedMaze` you always know it does.