### PR TITLE
change num_workers

### DIFF
--- a/maze_transformer/training/config.py
+++ b/maze_transformer/training/config.py
@@ -123,7 +123,7 @@ _TRAINING_CONFIG_LIST: list[TrainConfig] = [
         batch_size=32,
         dataloader_cfg=dict(
             shuffle=True,
-            num_workers=16,
+            num_workers=8,
             persistent_workers=True,
             drop_last=True,
         ),


### PR DESCRIPTION
Addresses minor issue in #35 

Minor issue with num_workers used in training/config.py (changed tiny-v1 num_workers from 16 to 8, this config is used by integration/test_train_model.py).