### PR TITLE
Upgrade actions to use checkout@v3

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: pycln
         run: |
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Fixes deprecation warnings that actions was raising:

![image](https://user-images.githubusercontent.com/26048292/227178167-3c935eb3-37e8-4212-be7a-b485abc79c49.png)