### PR TITLE
[WIP] Suppress warning from setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,10 @@ filterwarnings = [
     "ignore:`np\\.\\w*` is a deprecated alias for:DeprecationWarning",
 
     # Warning from matplotlib. Issue: https://github.com/matplotlib/matplotlib/issues/25244
-    "ignore:Deprecated call to `pkg_resources.declare_namespace:DeprecationWarning"
+    "ignore:Deprecated call to `pkg_resources.declare_namespace:DeprecationWarning",
+
+    # Warning setuptools. Issue: https://github.com/pypa/setuptools/issues/2466
+    "ignore:pkg_resources is deprecated as an API:DeprecationWarning"
 ]
 norecursedirs="tests/helpers"
 


### PR DESCRIPTION
Suppress DeprecationWarning coming from setuptools

From https://github.com/spdx/tools-python/issues/507 it looks like it may be coming from the `__import__("pkg_resources").declare_namespace(__name__)` line in isort but I don't know how to diagnose these properly 🤔 