### PR TITLE
Add tests for path evals and a few new evals

### DIFF
--- a/maze_transformer/evaluation/path_evals.py
+++ b/maze_transformer/evaluation/path_evals.py
@@ -89,7 +89,9 @@ class PathEvals:
         """fraction of connections in prediction which are are valid paths on the maze"""
 
         num_connections: float = len(prediction) - 1.0
-        return PathEvals.num_connections_adjacent(maze, prediction) / max(num_connections, 1.0)
+        return PathEvals.num_connections_adjacent(maze, prediction) / max(
+            num_connections, 1.0
+        )
 
     @register_method(evals)
     @staticmethod

--- a/maze_transformer/evaluation/path_evals.py
+++ b/maze_transformer/evaluation/path_evals.py
@@ -23,14 +23,18 @@ class PathEvalFunction(Protocol):
 
 def path_as_segments_iter(path: MazePath) -> Iterable[tuple]:
     """
-    Iterate over the segments of a path.
+    Iterate over the segments of a path (ie each consecutive pair).
     """
-    i: int
     step_start: Coord | CoordTup
     step_end: Coord | CoordTup
     for i, step_start in enumerate(path[:-1]):
         step_end = path[i + 1]
         yield step_start, step_end
+
+
+def is_adjacent(node1: Coord, node2: Coord) -> bool:
+    """Check that the nodes are at most 1 step apart (diagonal steps not possible)"""
+    return np.abs(node1 - node2).sum() == 1
 
 
 class PathEvals:
@@ -41,29 +45,20 @@ class PathEvals:
     @register_method(evals)
     @staticmethod
     def node_overlap(solution: MazePath, prediction: MazePath, **_) -> float:
-        """number of shared nodes (any order) / total number of (unique) nodes"""
-        if len(prediction) <= 1:
-            return 0.0
+        """number of shared nodes (any order) / total number of (unique) nodes in solution"""
 
-        n_shared: int = 0
         solution_set = {tuple(coord) for coord in solution}
         prediction_set = {tuple(coord) for coord in prediction}
 
-        for coord in solution:
-            if tuple(coord) in prediction_set:
-                n_shared += 1
-        return n_shared / len(solution_set)
+        return len(prediction_set & solution_set) / len(solution_set)
 
     @register_method(evals)
     @staticmethod
     def num_connections_adjacent_lattice(prediction: MazePath, **_) -> float:
         """number of the connections in prediction which actually connect nodes that are adjacent on the lattice, ignoring if they are adjacent on the maze"""
-        if len(prediction) <= 1:
-            return 0.0
-
-        n_adj: int = 0
+        n_adj = 0.0
         for step_start, step_end in path_as_segments_iter(prediction):
-            if (np.abs(step_start - step_end).sum() == 1).all():
+            if is_adjacent(step_start, step_end):
                 n_adj += 1
 
         return n_adj
@@ -79,11 +74,7 @@ class PathEvals:
     @staticmethod
     def num_connections_adjacent(maze: LatticeMaze, prediction: MazePath, **_) -> float:
         """number of connections in prediction which are are valid paths on the maze"""
-
-        if len(prediction) <= 1:
-            return 0.0
-
-        n_connected: int = 0
+        n_connected = 0.0
         for step_start, step_end in path_as_segments_iter(prediction):
             if maze.nodes_connected(step_start, step_end):
                 n_connected += 1
@@ -97,4 +88,40 @@ class PathEvals:
     ) -> float:
         """fraction of connections in prediction which are are valid paths on the maze"""
 
-        return PathEvals.num_connections_adjacent(maze, prediction) / len(prediction)
+        num_connections = len(prediction) - 1
+        return PathEvals.num_connections_adjacent(maze, prediction) / num_connections
+
+    @register_method(evals)
+    @staticmethod
+    def exact_path_predicted(solution: MazePath, prediction: MazePath, **_) -> float:
+        """Was the maze successfully solved?"""
+        return float(np.all(solution == prediction))
+
+    @register_method(evals)
+    @staticmethod
+    def solution_length(solution: MazePath, **_) -> float:
+        return float(len(solution))
+
+    @register_method(evals)
+    @staticmethod
+    def streak_length_until_incorrect(
+        solution: MazePath,
+        prediction: MazePath,
+        **_,
+    ) -> float:
+        """How many moves until the predicted path deviates from the solution"""
+        prediction = prediction.tolist()
+        solution = solution.tolist()
+        streak_length = 0.0
+
+        for i in range(max(len(prediction), len(solution))):
+            if (
+                i + 1 > len(prediction)
+                or i + 1 > len(solution)
+                or prediction[i] != solution[i]
+            ):
+                return streak_length
+            else:
+                streak_length += 1
+
+        return streak_length

--- a/maze_transformer/evaluation/path_evals.py
+++ b/maze_transformer/evaluation/path_evals.py
@@ -89,7 +89,7 @@ class PathEvals:
         """fraction of connections in prediction which are are valid paths on the maze"""
 
         num_connections: float = len(prediction) - 1.0
-        return PathEvals.num_connections_adjacent(maze, prediction) / num_connections
+        return PathEvals.num_connections_adjacent(maze, prediction) / max(num_connections, 1.0)
 
     @register_method(evals)
     @staticmethod

--- a/maze_transformer/evaluation/path_evals.py
+++ b/maze_transformer/evaluation/path_evals.py
@@ -56,7 +56,7 @@ class PathEvals:
     @staticmethod
     def num_connections_adjacent_lattice(prediction: MazePath, **_) -> float:
         """number of the connections in prediction which actually connect nodes that are adjacent on the lattice, ignoring if they are adjacent on the maze"""
-        n_adj = 0.0
+        n_adj: float = 0.0
         for step_start, step_end in path_as_segments_iter(prediction):
             if is_adjacent(step_start, step_end):
                 n_adj += 1
@@ -74,7 +74,7 @@ class PathEvals:
     @staticmethod
     def num_connections_adjacent(maze: LatticeMaze, prediction: MazePath, **_) -> float:
         """number of connections in prediction which are are valid paths on the maze"""
-        n_connected = 0.0
+        n_connected: float = 0.0
         for step_start, step_end in path_as_segments_iter(prediction):
             if maze.nodes_connected(step_start, step_end):
                 n_connected += 1
@@ -88,14 +88,14 @@ class PathEvals:
     ) -> float:
         """fraction of connections in prediction which are are valid paths on the maze"""
 
-        num_connections = len(prediction) - 1
+        num_connections: float = len(prediction) - 1.0
         return PathEvals.num_connections_adjacent(maze, prediction) / num_connections
 
     @register_method(evals)
     @staticmethod
     def exact_path_predicted(solution: MazePath, prediction: MazePath, **_) -> float:
         """Was the maze successfully solved?"""
-        return float(np.all(solution == prediction))
+        return float(np.array_equal(solution, prediction))
 
     @register_method(evals)
     @staticmethod
@@ -112,7 +112,7 @@ class PathEvals:
         """How many moves until the predicted path deviates from the solution"""
         prediction = prediction.tolist()
         solution = solution.tolist()
-        streak_length = 0.0
+        streak_length: float = 0.0
 
         for i in range(max(len(prediction), len(solution))):
             if (

--- a/tests/unit/maze_transformer/evaluation/test_path_evals.py
+++ b/tests/unit/maze_transformer/evaluation/test_path_evals.py
@@ -73,7 +73,7 @@ def test_fraction_connections_adjacent():
 def test_exact_path_predicted():
     solution = np.array([(0, 0), (0, 1), (1, 1)])
     good_prediction = solution
-    bad_prediction = np.array([(0, 0), (1, 1), (0, 1)])
+    bad_prediction = np.array([(0, 0), (1, 1)])
 
     assert PathEvals.exact_path_predicted(solution, good_prediction) == 1.0
     assert PathEvals.exact_path_predicted(solution, bad_prediction) == 0.0

--- a/tests/unit/maze_transformer/evaluation/test_path_evals.py
+++ b/tests/unit/maze_transformer/evaluation/test_path_evals.py
@@ -66,8 +66,10 @@ def test_fraction_connections_adjacent():
     maze = LatticeMaze(connection_list=connection_list)
     # first pair is not connected, 2nd pair is
     prediction = np.array([(0, 0), (1, 0), (1, 1)])
+    short_prediction = np.array([(0, 0)])
 
     assert PathEvals.fraction_connections_adjacent(maze, prediction) == 0.5
+    assert PathEvals.fraction_connections_adjacent(maze, short_prediction) == 0.0
 
 
 def test_exact_path_predicted():

--- a/tests/unit/maze_transformer/evaluation/test_path_evals.py
+++ b/tests/unit/maze_transformer/evaluation/test_path_evals.py
@@ -1,0 +1,97 @@
+import numpy as np
+
+from maze_transformer.evaluation.path_evals import PathEvals
+from maze_transformer.generation.latticemaze import LatticeMaze
+from maze_transformer.generation.utils import bool_array_from_string
+
+
+def test_node_overlap_short_match():
+    # this will happen if origin and target are the same. Correct behaviour would be an immediate path_end
+    prediction = np.array([(1, 2)])
+    solution = np.array([(1, 2)])
+
+    assert PathEvals.node_overlap(solution, prediction) == 1.0
+
+
+def test_node_overlap():
+    prediction = np.array([(1, 2), (2, 3), (1, 1)])
+    solution = np.array([(2, 2), (1, 2)])
+
+    assert PathEvals.node_overlap(solution, prediction) == 0.5
+
+
+def test_num_connections_adjacent_lattice():
+    prediction = np.array([(0, 0), (0, 1), (1, 2)])
+
+    assert PathEvals.num_connections_adjacent_lattice(prediction) == 1.0
+
+
+def fraction_connections_adjacent_lattice():
+    prediction = np.array([(0, 0), (0, 1), (1, 2)])
+
+    assert PathEvals.num_connections_adjacent_lattice(prediction) == 0.5
+
+
+def test_num_connections_adjacent():
+    connection_list = bool_array_from_string(
+        """
+        F T
+        F F
+
+        T F
+        T F
+        """,
+        shape=[2, 2, 2],
+    )
+
+    maze = LatticeMaze(connection_list=connection_list)
+    # first pair is not connected, 2nd pair is
+    prediction = np.array([(0, 0), (1, 0), (1, 1)])
+
+    assert PathEvals.num_connections_adjacent(maze, prediction) == 1.0
+
+
+def test_fraction_connections_adjacent():
+    connection_list = bool_array_from_string(
+        """
+        F T
+        F F
+
+        T F
+        T F
+        """,
+        shape=[2, 2, 2],
+    )
+
+    maze = LatticeMaze(connection_list=connection_list)
+    # first pair is not connected, 2nd pair is
+    prediction = np.array([(0, 0), (1, 0), (1, 1)])
+
+    assert PathEvals.fraction_connections_adjacent(maze, prediction) == 0.5
+
+
+def test_exact_path_predicted():
+    solution = np.array([(0, 0), (0, 1), (1, 1)])
+    good_prediction = solution
+    bad_prediction = np.array([(0, 0), (1, 1), (0, 1)])
+
+    assert PathEvals.exact_path_predicted(solution, good_prediction) == 1.0
+    assert PathEvals.exact_path_predicted(solution, bad_prediction) == 0.0
+
+
+def test_solution_length():
+    solution = np.array([(0, 0), (0, 1)])
+
+    assert PathEvals.solution_length(solution) == 2
+
+
+def test_streak_length_until_incorrect():
+    solution = np.array([(0, 0), (0, 1), (0, 2)])
+    terrible_prediction = np.array([(0, 1)])
+    bad_prediction = np.array([(0, 0), (0, 1), (2, 2)])
+    long_prediction = np.concatenate([solution, np.array([(0, 2), (0, 2)])])
+
+    assert PathEvals.streak_length_until_incorrect(solution, terrible_prediction) == 0.0
+    assert PathEvals.streak_length_until_incorrect(solution, bad_prediction) == 2.0
+    assert PathEvals.streak_length_until_incorrect(solution, solution) == 3.0
+    assert PathEvals.streak_length_until_incorrect(solution, long_prediction) == 3.0


### PR DESCRIPTION
Changes:
- Unit tests for all evals
- Removed `len(prediction) <= 1` check as I don't think it is correct behaviour (pending discussion with Micheal on this one)
- Added `exact_path_predicted`, `solution_length`, `streak_length_until_incorrect` evals
- Ensured all evals return floats (not sure this is necessary, but seems best to be consistent in the interface)